### PR TITLE
Update README.md

### DIFF
--- a/packages/sanddance/README.md
+++ b/packages/sanddance/README.md
@@ -32,7 +32,7 @@ Add these to the `dependencies` section of your `package.json`, then run `npm in
 ```json
 "@deck.gl/core": "6.4",
 "@deck.gl/layers": "6.4",
-"@msrvida/sanddance": "^1",
+"@msrvida/sanddance": "^2",
 "luma.gl": "6.4",
 "vega": "^5.8"
 ```


### PR DESCRIPTION
Updating "@msrvida/sanddance" to "^2", because SandDance 1 used vega 4, while vega 5 is used for SandDance 2.