### PR TITLE
Add HASH to "Where can I use SandDance?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ SandDance was created by the [Microsoft Research VIDA Group](https://aka.ms/vida
 * [Azure Data Studio](https://docs.microsoft.com/en-us/sql/azure-data-studio/sanddance-extension?view=sql-server-2017)
 * [VSCode extension](https://marketplace.visualstudio.com/items?itemName=msrvida.vscode-sanddance)
 * [Observable](https://observablehq.com/collection/@danmarshall/sanddance)
+* [HASH Core IDE](https://core.hash.ai/) - [*see 'Step Explorer' documentation*](https://docs.hash.ai/core/views#step-explorer)
 * In your own JavaScript apps - see below
 
 ## Component architecture


### PR DESCRIPTION
Since [2020-06-01](https://hash.ai/updates/2020-06-01) HASH has included SandDance in its Core IDE as a means of exploring multi-agent simulation outputs. Not sure if this is an appropriate way to suggest inclusion here (please disregard this PR if not!), but we figured it was a novel enough use case to maybe be of interest.

Very happy to chat through our implementation in any way. @jkelleyrtp has primarily worked on this our side. We'd be interested in contributing w/r/t performance in the future. 😄 