### PR TITLE
fix doc for sanddance-react

### DIFF
--- a/docs/docs/sanddance-react/v3/index.md
+++ b/docs/docs/sanddance-react/v3/index.md
@@ -32,9 +32,9 @@ import * as vega from 'vega';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { SandDance, SandDanceReact } from '@msrvida/sanddance-react';
+import { use as SandDanceUse, SandDanceReact } from '@msrvida/sanddance-react';
 
-SandDance.use(React, ReactDOM, vega, deck, layers, luma);
+SandDanceUse(React, ReactDOM, vega, deck, layers, luma);
 ```
 
 ## For more information

--- a/packages/sanddance-react/README.md
+++ b/packages/sanddance-react/README.md
@@ -28,9 +28,9 @@ import * as vega from 'vega';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { SandDance, SandDanceReact } from '@msrvida/sanddance-react';
+import { use as SandDanceUse, SandDanceReact } from '@msrvida/sanddance-react';
 
-SandDance.use(React, ReactDOM, vega, deck, layers, luma);
+SandDanceUse(React, ReactDOM, vega, deck, layers, luma);
 ```
 
 ## For more information


### PR DESCRIPTION
`SandDance.use`  is `(vega: VegaBase, deck: DeckBase, layers: DeckLayerBase, luma: LumaBase): void`

should use `use` in `sanddance-react` instead, which is ` react: React, reactDOM: ReactDOM, vega: VegaBase, deck: DeckBase, layers: DeckLayerBase, luma: LumaBase`