### PR TITLE
Fixing broken doc links.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,10 +33,10 @@ Smooth animated transitions between views help you to maintain context as you in
 <h2 id="component-architecture">Component architecture</h2>
 <p>SandDance is an offering of several JavaScript components:</p>
 <ul>
-<li><a href="/docs/sanddance/v3/">sanddance</a> - the core SandDance visualization canvas.</li>
-<li><a href="/docs/sanddance-react/v3/">sanddance-react</a> - the core SandDance visualization canvas for use in React based applications.</li>
-<li><a href="/docs/sanddance-vue/v3/">sanddance-vue</a> - the core SandDance visualization canvas for use in Vue based applications.</li>
-<li><a href="/docs/sanddance-explorer/v3/">sanddance-explorer</a> - the core SandDance visualization canvas with UI to enable data exploration, for use in React based applications.</li>
+<li><a href="/SandDance/docs/sanddance/v3/">sanddance</a> - the core SandDance visualization canvas.</li>
+<li><a href="/SandDance/docs/sanddance-react/v3/">sanddance-react</a> - the core SandDance visualization canvas for use in React based applications.</li>
+<li><a href="/SandDance/docs/sanddance-vue/v3/">sanddance-vue</a> - the core SandDance visualization canvas for use in Vue based applications.</li>
+<li><a href="/SandDance/docs/sanddance-explorer/v3/">sanddance-explorer</a> - the core SandDance visualization canvas with UI to enable data exploration, for use in React based applications.</li>
 </ul>
 <h2 id="publications">Publications</h2>
 <ul>

--- a/scripts/readme.js
+++ b/scripts/readme.js
@@ -40,10 +40,10 @@ function convertHomePage() {
 const map = {
     "https://microsoft.github.io": "",
     "dev.md": "https://github.com/Microsoft/SandDance/blob/master/dev.md",
-    "packages/sanddance/README.md": `/docs/sanddance/${pubversion}/`,
-    "packages/sanddance-vue/README.md": `/docs/sanddance-vue/${pubversion}/`,
-    "packages/sanddance-react/README.md": `/docs/sanddance-react/${pubversion}/`,
-    "packages/sanddance-explorer/README.md": `/docs/sanddance-explorer/${pubversion}/`
+    "packages/sanddance/README.md": `/SandDance/docs/sanddance/${pubversion}/`,
+    "packages/sanddance-vue/README.md": `/SandDance/docs/sanddance-vue/${pubversion}/`,
+    "packages/sanddance-react/README.md": `/SandDance/docs/sanddance-react/${pubversion}/`,
+    "packages/sanddance-explorer/README.md": `/SandDance/docs/sanddance-explorer/${pubversion}/`
 };
 
 //https://stackoverflow.com/questions/1144783/how-to-replace-all-occurrences-of-a-string-in-javascript


### PR DESCRIPTION
The links in the [Component Architecture section](https://microsoft.github.io/SandDance/) are broken, adding the repo title as a prefix should fix it.