### PR TITLE
use power scale for scatterplot size

### DIFF
--- a/packages/sanddance-specs/src/layouts/scatter.ts
+++ b/packages/sanddance-specs/src/layouts/scatter.ts
@@ -211,52 +211,52 @@ export class Scatter extends Layout {
             reverse: boolean,
             signal: string
         }[] = [
-                {
-                    column: x,
-                    xyz: 'x',
-                    scaleName: names.xScale,
-                    domain: backgroundImageExtents ?
-                        {
-                            signal: names.xExtent,
-                        }
-                        :
-                        {
-                            data: globalScope.data.name,
-                            field: safeFieldName(x.name),
-                        },
-                    reverse: false,
-                    signal: parentScope.sizeSignals.layoutWidth,
-                },
-                {
-                    column: y,
-                    xyz: 'y',
-                    scaleName: names.yScale,
-                    domain: backgroundImageExtents ?
-                        {
-                            signal: names.yExtent,
-                        }
-                        :
-                        {
-                            data: globalScope.data.name,
-                            field: safeFieldName(y.name),
-                        },
-                    reverse: true,
-                    signal: parentScope.sizeSignals.layoutHeight,
-                },
-                {
-                    column: z,
-                    xyz: 'z',
-                    scaleName: names.zScale,
-                    domain: {
+            {
+                column: x,
+                xyz: 'x',
+                scaleName: names.xScale,
+                domain: backgroundImageExtents ?
+                    {
+                        signal: names.xExtent,
+                    }
+                    :
+                    {
                         data: globalScope.data.name,
-                        field: z ? safeFieldName(z.name) : null,
+                        field: safeFieldName(x.name),
                     },
-                    reverse: false,
-                    signal: view === '3d'
-                        ? `(${globalScope.zSize}) * ${SignalNames.ZProportion}`
-                        : `10 * ${SignalNames.ZProportion}`,
+                reverse: false,
+                signal: parentScope.sizeSignals.layoutWidth,
+            },
+            {
+                column: y,
+                xyz: 'y',
+                scaleName: names.yScale,
+                domain: backgroundImageExtents ?
+                    {
+                        signal: names.yExtent,
+                    }
+                    :
+                    {
+                        data: globalScope.data.name,
+                        field: safeFieldName(y.name),
+                    },
+                reverse: true,
+                signal: parentScope.sizeSignals.layoutHeight,
+            },
+            {
+                column: z,
+                xyz: 'z',
+                scaleName: names.zScale,
+                domain: {
+                    data: globalScope.data.name,
+                    field: z ? safeFieldName(z.name) : null,
                 },
-            ];
+                reverse: false,
+                signal: view === '3d'
+                    ? `(${globalScope.zSize}) * ${SignalNames.ZProportion}`
+                    : `10 * ${SignalNames.ZProportion}`,
+            },
+        ];
         columnSignals.forEach(cs => {
             const { column, domain, reverse, scaleName, signal, xyz } = cs;
             if (!column) return;

--- a/packages/sanddance-specs/src/layouts/scatter.ts
+++ b/packages/sanddance-specs/src/layouts/scatter.ts
@@ -127,7 +127,8 @@ export class Scatter extends Layout {
             addScales(globalScope.scope,
                 {
                     name: names.sizeScale,
-                    type: 'linear',
+                    type: 'pow',
+                    exponent: 1 / (view === '3d' ? 3 : 2),
                     domain: [0, { signal: `${names.sizeExtent}[1]` }],
                     range: [0, { signal: names.sizeRange }],
                 },
@@ -210,52 +211,52 @@ export class Scatter extends Layout {
             reverse: boolean,
             signal: string
         }[] = [
-            {
-                column: x,
-                xyz: 'x',
-                scaleName: names.xScale,
-                domain: backgroundImageExtents ?
-                    {
-                        signal: names.xExtent,
-                    }
-                    :
-                    {
-                        data: globalScope.data.name,
-                        field: safeFieldName(x.name),
-                    },
-                reverse: false,
-                signal: parentScope.sizeSignals.layoutWidth,
-            },
-            {
-                column: y,
-                xyz: 'y',
-                scaleName: names.yScale,
-                domain: backgroundImageExtents ?
-                    {
-                        signal: names.yExtent,
-                    }
-                    :
-                    {
-                        data: globalScope.data.name,
-                        field: safeFieldName(y.name),
-                    },
-                reverse: true,
-                signal: parentScope.sizeSignals.layoutHeight,
-            },
-            {
-                column: z,
-                xyz: 'z',
-                scaleName: names.zScale,
-                domain: {
-                    data: globalScope.data.name,
-                    field: z ? safeFieldName(z.name) : null,
+                {
+                    column: x,
+                    xyz: 'x',
+                    scaleName: names.xScale,
+                    domain: backgroundImageExtents ?
+                        {
+                            signal: names.xExtent,
+                        }
+                        :
+                        {
+                            data: globalScope.data.name,
+                            field: safeFieldName(x.name),
+                        },
+                    reverse: false,
+                    signal: parentScope.sizeSignals.layoutWidth,
                 },
-                reverse: false,
-                signal: view === '3d'
-                    ? `(${globalScope.zSize}) * ${SignalNames.ZProportion}`
-                    : `10 * ${SignalNames.ZProportion}`,
-            },
-        ];
+                {
+                    column: y,
+                    xyz: 'y',
+                    scaleName: names.yScale,
+                    domain: backgroundImageExtents ?
+                        {
+                            signal: names.yExtent,
+                        }
+                        :
+                        {
+                            data: globalScope.data.name,
+                            field: safeFieldName(y.name),
+                        },
+                    reverse: true,
+                    signal: parentScope.sizeSignals.layoutHeight,
+                },
+                {
+                    column: z,
+                    xyz: 'z',
+                    scaleName: names.zScale,
+                    domain: {
+                        data: globalScope.data.name,
+                        field: z ? safeFieldName(z.name) : null,
+                    },
+                    reverse: false,
+                    signal: view === '3d'
+                        ? `(${globalScope.zSize}) * ${SignalNames.ZProportion}`
+                        : `10 * ${SignalNames.ZProportion}`,
+                },
+            ];
         columnSignals.forEach(cs => {
             const { column, domain, reverse, scaleName, signal, xyz } = cs;
             if (!column) return;

--- a/packages/sanddance-specs/src/layouts/scatter.ts
+++ b/packages/sanddance-specs/src/layouts/scatter.ts
@@ -128,7 +128,7 @@ export class Scatter extends Layout {
                 {
                     name: names.sizeScale,
                     type: 'pow',
-                    exponent: 1 / (view === '3d' ? 3 : 2),
+                    exponent: 0.5,
                     domain: [0, { signal: `${names.sizeExtent}[1]` }],
                     range: [0, { signal: names.sizeRange }],
                 },

--- a/test/sanddance-app.html
+++ b/test/sanddance-app.html
@@ -73,6 +73,7 @@
                     "y": "Latitude",
                     "color": "Obama",
                     "z": "Education",
+                    "size": "TotalPop",
                     "sort": "State"
                 },
                 "scheme": "redblue",


### PR DESCRIPTION
When mapping a column to the Size role in Scatter charts, this change will use the area of a square instead of the width/height.