### PR TITLE
Add License section to README

### DIFF
--- a/extensions/azdata-sanddance/README.md
+++ b/extensions/azdata-sanddance/README.md
@@ -28,3 +28,7 @@ Major upgrade to layout engine
 ### 1.0.0
 
 Initial release of azdata-sanddance
+
+## License
+
+This extension is licensed under the [MIT License](https://github.com/microsoft/SandDance/blob/main/LICENSE).


### PR DESCRIPTION
Requirement by CELA that all ADS extensions must have a license section in their README with a link to the applicable license.